### PR TITLE
Make Plugin mimic upcoming native feature

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,24 @@
+const prefix = "data-ph-capture-attribute-";
+
 // Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
 function getMatchingAttributes(o, prefix) {
     return Object.keys(o).filter((k) =>
         k.toString().startsWith(`attr__${prefix}`)
     )
 }
+
+function convertDataAttribute(input: string): string {
+  //  the 6 extra chars are dure to the additional prefix "attr__"
+  const withoutDataPrefix = input.startsWith("attr__"+prefix) ? input.slice(prefix.length + 6) : input;
+
+  // Convert from kebab-case to snake_case
+  const snakeCase = withoutDataPrefix.replace(/-/g, "_");
+
+  return snakeCase;
+}
+
 // Processes each event, optionally transforming it
-export function processEvent(event, { config }) {
+export function processEvent(event, _) {
     // only process autocapture events
     if (
         event.event == "$autocapture" &&
@@ -13,12 +26,12 @@ export function processEvent(event, { config }) {
     ) {
         // for each element, find all matching attributes
         event.properties["$elements"].forEach(function (element, i) {
-            getMatchingAttributes(element, config.prefix).forEach(function (
+            getMatchingAttributes(element, prefix).forEach(function (
                 key,
                 i
             ) {
                 // add attribute without attr__ prefix to event
-                event.properties[key.slice(6)] = element[key]
+                event.properties[convertDataAttribute(key)] = element[key]
             })
         })
     }

--- a/plugin.json
+++ b/plugin.json
@@ -1,16 +1,3 @@
 {
-    "name": "element-attribute-to-property",
-    "config": [
-        {
-            "markdown": "Specify the prefix for html element attributes that should be added to events as property"
-        },
-        {
-            "key": "prefix",
-            "name": "Attribute Prefix",
-            "type": "string",
-            "hint": "if a the html attribute starts with this string, add it as a property to the event",
-            "default": "data-ux",
-            "required": true
-        }
-    ]
+    "name": "element-attribute-to-property"
 }


### PR DESCRIPTION
A future version of PostHog will provide the plugin's functionality natively and we plan on using it:
https://posthog.com/docs/product-analytics/autocapture#capturing-additional-properties-in-autocapture-events

Since there's no ETA as to when we will upgrade to that new version yet we cannot discard the plugin just yet, but should make it mimic the behavior of the upcoming feature as closely as possible, so we won't have any breaks in our data when we introduce it.

On the platform we give the attributes the form
data-ph-capture-attribute-XXX, since that's what the new feature will expect

The changes to the plugin are twofold:

1. The upcoming feature, unlike our custom Plugin, will use only the XXX part as the key, so we change the Plugin to do the same.
2. We hard-code the new prefix to be data-ph-capture-attribute- since there now is a standard we won't want to deviate from.

https://machtfit.atlassian.net/browse/DEV-785